### PR TITLE
PLS-0001 - Add find find cheapest sailing functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
+gem 'dry-monads'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,13 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     drb (2.2.1)
+    dry-core (1.0.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-monads (1.6.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
     error_highlight (0.6.0)
     erubi (1.12.0)
     faker (3.2.3)
@@ -233,6 +240,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  dry-monads
   error_highlight (>= 0.4.0)
   faker
   pry (~> 0.14.2)

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -1,0 +1,27 @@
+class RoutesController < ApplicationController
+  def index
+    result = GetCheapestEndpoint.new(
+      origin_port: origin_port, destination_port: destination_port, sailings: sailings
+    ).call
+
+    if result.success?
+      render json: result.value!.to_json, status: :ok
+    else
+      render json: { error: result.failure }, status: :bad_request
+    end
+  end
+
+  private
+
+  def origin_port
+    params[:origin_port]
+  end
+
+  def destination_port
+    params[:destination_port]
+  end
+
+  def sailings
+    SailingsBuilder.new.call
+  end
+end

--- a/app/models/sailing.rb
+++ b/app/models/sailing.rb
@@ -1,0 +1,35 @@
+class Sailing
+  attr_accessor :sailing_code, :origin_port, :destination_port, :departure_date, :arrival_date, :rate,
+              :rate_currency, :usd, :jpy
+
+  def initialize(attributes ={})
+    attributes.each do |key, val|
+      instance_variable_set("@#{key}", val)
+    end
+  end
+
+  def rate_in_euro
+    (rate.to_f / (exchange_rates[rate_currency.downcase.to_sym] || 1)).round(2)
+  end
+
+  def to_json
+    {
+      "origin_port": origin_port,
+      "destination_port": destination_port,
+      "departure_date": departure_date,
+      "arrival_date": arrival_date,
+      "sailing_code": sailing_code,
+      "rate": rate,
+      "rate_currency": rate_currency
+    }.to_json
+  end
+
+  private
+
+  def exchange_rates
+    {
+      usd: usd,
+      jpy: jpy
+    }
+  end
+end

--- a/app/services/get_cheapest_endpoint.rb
+++ b/app/services/get_cheapest_endpoint.rb
@@ -1,0 +1,33 @@
+class GetCheapestEndpoint
+  include Dry::Monads[:result]
+
+  attr_reader :sailings, :origin_port, :destination_port
+
+  def initialize(origin_port:, destination_port:, sailings:)
+    @sailings = sailings
+    @origin_port = origin_port
+    @destination_port = destination_port
+  end
+
+  def call
+    return Failure("Invalid origin/destination port") unless within_valid_endpoints?
+
+    Success(eligible_sailings.min_by(&:rate_in_euro))
+  end
+
+  private
+
+  def eligible_sailings
+    @eligible_sailings ||= sailings.select do |sailing|
+      sailing.origin_port == origin_port && sailing.destination_port == destination_port
+    end
+  end
+
+  def within_valid_endpoints?
+    valid_endpoints.include?(origin_port) && valid_endpoints.include?(destination_port)
+  end
+
+  def valid_endpoints
+    @valid_endpoints ||=  sailings.map {|sailing| [sailing.origin_port, sailing.destination_port]}.flatten.uniq
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  resources :routes, only: [:index]
 end

--- a/lib/sailings_builder.rb
+++ b/lib/sailings_builder.rb
@@ -1,0 +1,30 @@
+require 'json'
+
+class SailingsBuilder
+  attr_reader :sailings, :rates, :exchange_rates
+
+  def initialize(filepath = 'response.json')
+    file = File.read(filepath)
+    data = JSON.parse(file)
+
+    @sailings = data['sailings']
+    @rates = data['rates']
+    @exchange_rates = data['exchange_rates']
+  end
+
+  def call
+    sailings.map do |sailing|
+      Sailing.new **sailing, **rate_attributes(sailing['sailing_code']), **rate_exchange_attributes(sailing['departure_date'])
+    end
+  end
+
+  private
+
+  def rate_attributes(sailing_code)
+    rates.find {|rate| rate['sailing_code'] == sailing_code}
+  end
+
+  def rate_exchange_attributes(departure_date)
+    exchange_rates[departure_date]
+  end
+end

--- a/response.json
+++ b/response.json
@@ -1,0 +1,144 @@
+{
+  "sailings": [
+    {
+      "origin_port": "CNSHA",
+      "destination_port": "NLRTM",
+      "departure_date": "2022-02-01",
+      "arrival_date": "2022-03-01",
+      "sailing_code": "ABCD"
+    },
+    {
+      "origin_port": "CNSHA",
+      "destination_port": "NLRTM",
+      "departure_date": "2022-02-02",
+      "arrival_date": "2022-03-02",
+      "sailing_code": "EFGH"
+    },
+    {
+      "origin_port": "CNSHA",
+      "destination_port": "NLRTM",
+      "departure_date": "2022-01-31",
+      "arrival_date": "2022-02-28",
+      "sailing_code": "IJKL"
+    },
+    {
+      "origin_port": "CNSHA",
+      "destination_port": "NLRTM",
+      "departure_date": "2022-01-30",
+      "arrival_date": "2022-03-05",
+      "sailing_code": "MNOP"
+    },
+    {
+      "origin_port": "CNSHA",
+      "destination_port": "NLRTM",
+      "departure_date": "2022-01-29",
+      "arrival_date": "2022-02-15",
+      "sailing_code": "QRST"
+    },
+    {
+      "origin_port": "CNSHA",
+      "destination_port": "ESBCN",
+      "departure_date": "2022-01-29",
+      "arrival_date": "2022-02-12",
+      "sailing_code": "ERXQ"
+    },
+    {
+      "origin_port": "ESBCN",
+      "destination_port": "NLRTM",
+      "departure_date": "2022-02-15",
+      "arrival_date": "2022-03-29",
+      "sailing_code": "ETRF"
+    },
+    {
+      "origin_port": "ESBCN",
+      "destination_port": "NLRTM",
+      "departure_date": "2022-02-16",
+      "arrival_date": "2022-02-20",
+      "sailing_code": "ETRG"
+    },
+    {
+      "origin_port": "ESBCN",
+      "destination_port": "BRSSZ",
+      "departure_date": "2022-02-16",
+      "arrival_date": "2022-03-14",
+      "sailing_code": "ETRB"
+    }
+  ],
+  "rates": [
+    {
+      "sailing_code": "ABCD",
+      "rate": "589.30",
+      "rate_currency": "USD"
+    },
+    {
+      "sailing_code": "EFGH",
+      "rate": "890.32",
+      "rate_currency": "EUR"
+    },
+    {
+      "sailing_code": "IJKL",
+      "rate": "97453",
+      "rate_currency": "JPY"
+    },
+    {
+      "sailing_code": "MNOP",
+      "rate": "456.78",
+      "rate_currency": "USD"
+    },
+    {
+      "sailing_code": "QRST",
+      "rate": "761.96",
+      "rate_currency": "EUR"
+    },
+    {
+      "sailing_code": "ERXQ",
+      "rate": "261.96",
+      "rate_currency": "EUR"
+    },
+    {
+      "sailing_code": "ETRF",
+      "rate": "70.96",
+      "rate_currency": "USD"
+    },
+    {
+      "sailing_code": "ETRG",
+      "rate": "69.96",
+      "rate_currency": "USD"
+    },
+    {
+      "sailing_code": "ETRB",
+      "rate": "439.96",
+      "rate_currency": "USD"
+    }
+  ],
+  "exchange_rates": {
+    "2022-01-29": {
+      "usd": 1.1138,
+      "jpy": 130.85
+    },
+    "2022-01-30": {
+      "usd": 1.1138,
+      "jpy": 132.97
+    },
+    "2022-01-31": {
+      "usd": 1.1156,
+      "jpy": 131.2
+    },
+    "2022-02-01": {
+      "usd": 1.126,
+      "jpy": 130.15
+    },
+    "2022-02-02": {
+      "usd": 1.1323,
+      "jpy": 133.91
+    },
+    "2022-02-15": {
+      "usd": 1.1483,
+      "jpy": 149.93
+    },
+    "2022-02-16": {
+      "usd": 1.1482,
+      "jpy": 149.93
+    }
+  }
+}

--- a/spec/controllers/routes_controller_spec.rb
+++ b/spec/controllers/routes_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe RoutesController do
+  before do
+    service = allow(GetCheapestEndpoint)
+      .to(receive(:new).with(origin_port: origin_port, destination_port: destination_port, sailings: anything))
+      .and_return(result)
+    # allow(service).to receive(:call).and_return(double(success?: true))
+  end
+
+  describe "GET index" do
+    context "when origin and destination ports are valid" do
+      let(:origin_port) { 'origin_port' }
+      let(:destination_port) { 'destination_port' }
+      let(:sailings) { SailingsBuilder.new.call }
+      let(:result) { double(call: double(success?: true, value!: double)) }
+
+      it "return value" do
+        get :index, params: { origin_port: origin_port, destination_port: destination_port}
+
+        expect(response.code).to eq("200")
+      end
+    end
+
+    context "when origin or destination ports are invalid" do
+      let(:origin_port) { 'origin_port' }
+      let(:destination_port) { 'destination_port' }
+      let(:sailings) { SailingsBuilder.new.call }
+      let(:result) { double(call: double(success?: false, failure: double)) }
+
+      it "return value" do
+        get :index, params: { origin_port: origin_port, destination_port: destination_port}
+
+        expect(response.code).to eq("400")
+      end
+    end
+  end
+end

--- a/spec/lib/sailings_builder_spec.rb
+++ b/spec/lib/sailings_builder_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+describe SailingsBuilder do
+  subject { described_class.new }
+
+  let(:sailings) do
+    [
+      {
+        "origin_port" => "CNSHA",
+        "destination_port" => "NLRTM",
+        "departure_date" => "2022-02-01",
+        "arrival_date" => "2022-03-01",
+        "sailing_code" => "ABCD"
+      },
+      {
+        "origin_port" => "CNSHA",
+        "destination_port" => "NLRTM",
+        "departure_date" => "2022-02-02",
+        "arrival_date" => "2022-03-02",
+        "sailing_code" => "EFGH"
+      },
+      {
+        "origin_port" => "CNSHA",
+        "destination_port" => "NLRTM",
+        "departure_date" => "2022-01-31",
+        "arrival_date" => "2022-02-28",
+        "sailing_code" => "IJKL"
+      },
+      {
+        "origin_port" => "CNSHA",
+        "destination_port" => "NLRTM",
+        "departure_date" => "2022-01-30",
+        "arrival_date" => "2022-03-05",
+        "sailing_code" => "MNOP"
+      },
+      {
+        "origin_port" => "CNSHA",
+        "destination_port" => "NLRTM",
+        "departure_date" => "2022-01-29",
+        "arrival_date" => "2022-02-15",
+        "sailing_code" => "QRST"
+      },
+      {
+        "origin_port" => "CNSHA",
+        "destination_port" => "ESBCN",
+        "departure_date" => "2022-01-29",
+        "arrival_date" => "2022-02-12",
+        "sailing_code" => "ERXQ"
+      },
+      {
+        "origin_port" => "ESBCN",
+        "destination_port" => "NLRTM",
+        "departure_date" => "2022-02-15",
+        "arrival_date" => "2022-03-29",
+        "sailing_code" => "ETRF"
+      },
+      {
+        "origin_port" => "ESBCN",
+        "destination_port" => "NLRTM",
+        "departure_date" => "2022-02-16",
+        "arrival_date" => "2022-02-20",
+        "sailing_code" => "ETRG"
+      },
+      {
+        "origin_port" => "ESBCN",
+        "destination_port" => "BRSSZ",
+        "departure_date" => "2022-02-16",
+        "arrival_date" => "2022-03-14",
+        "sailing_code" => "ETRB"
+      }
+    ]
+  end
+  let(:rates) do
+    [
+      {
+        "sailing_code" => "ABCD",
+        "rate" => "589.30",
+        "rate_currency" => "USD"
+      },
+      {
+        "sailing_code" => "EFGH",
+        "rate" => "890.32",
+        "rate_currency" => "EUR"
+      },
+      {
+        "sailing_code" => "IJKL",
+        "rate" => "97453",
+        "rate_currency" => "JPY"
+      },
+      {
+        "sailing_code" => "MNOP",
+        "rate" => "456.78",
+        "rate_currency" => "USD"
+      },
+      {
+        "sailing_code" => "QRST",
+        "rate" => "761.96",
+        "rate_currency" => "EUR"
+      },
+      {
+        "sailing_code" => "ERXQ",
+        "rate" => "261.96",
+        "rate_currency" => "EUR"
+      },
+      {
+        "sailing_code" => "ETRF",
+        "rate" => "70.96",
+        "rate_currency" => "USD"
+      },
+      {
+        "sailing_code" => "ETRG",
+        "rate" => "69.96",
+        "rate_currency" => "USD"
+      },
+      {
+        "sailing_code" => "ETRB",
+        "rate" => "439.96",
+        "rate_currency" => "USD"
+      }
+    ]
+  end
+  let(:exchange_rates) do
+    {
+      "2022-01-29" => {
+        "usd" => 1.1138,
+        "jpy" => 130.85
+      },
+      "2022-01-30" => {
+        "usd" => 1.1138,
+        "jpy" => 132.97
+      },
+      "2022-01-31" => {
+        "usd" => 1.1156,
+        "jpy" => 131.2
+      },
+      "2022-02-01" => {
+        "usd" => 1.126,
+        "jpy" => 130.15
+      },
+      "2022-02-02" => {
+        "usd" => 1.1323,
+        "jpy" => 133.91
+      },
+      "2022-02-15" => {
+        "usd" => 1.1483,
+        "jpy" => 149.93
+      },
+      "2022-02-16" => {
+        "usd" => 1.1482,
+        "jpy" => 149.93
+      }
+    }
+  end
+
+  it 'returns valid sailings data' do
+    expect(subject.sailings).to match_array(sailings)
+  end
+
+  it 'returns valid rates data' do
+    expect(subject.rates).to match_array(rates)
+  end
+
+  it 'returns valid exchange rates data' do
+    expect(subject.exchange_rates).to match(exchange_rates)
+  end
+end

--- a/spec/models/sailing_spec.rb
+++ b/spec/models/sailing_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe Sailing do
+  let(:sailing) { described_class.new(**sailing_attributes) }
+
+  context 'when rate_currency is usd' do
+    let(:sailing_attributes) do
+      {"origin_port"=>"CNSHA",
+       "destination_port"=>"NLRTM",
+       "departure_date"=>"2022-02-01",
+       "arrival_date"=>"2022-03-01",
+       "sailing_code"=>"ABCD",
+       "rate"=>"589.30",
+       "rate_currency"=>"USD",
+       "usd"=>1.126,
+       "jpy"=>130.15}
+    end
+    let(:rate_in_euro) { 523.36 }
+
+    it 'returns rate in euro' do
+      expect(sailing.rate_in_euro).to eq(rate_in_euro)
+    end
+  end
+
+  context 'when rate_currency is jpy' do
+    let(:sailing_attributes) do
+      {"origin_port"=>"CNSHA",
+       "destination_port"=>"NLRTM",
+       "departure_date"=>"2022-01-31",
+       "arrival_date"=>"2022-02-28",
+       "sailing_code"=>"IJKL",
+       "rate"=>"97453",
+       "rate_currency"=>"JPY",
+       "usd"=>1.1156,
+       "jpy"=>131.2}
+    end
+    let(:rate_in_euro) { 742.78 }
+
+    it 'returns rate in euro' do
+      expect(sailing.rate_in_euro).to eq(rate_in_euro)
+    end
+
+    context "#to_json" do
+      it 'returns valid json' do
+        expect(JSON.parse(sailing.to_json)).to be_a(Hash)
+      end
+    end
+  end
+end

--- a/spec/services/get_cheapest_endpoint_spec.rb
+++ b/spec/services/get_cheapest_endpoint_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe GetCheapestEndpoint do
+  subject do
+    described_class.new(origin_port: origin_port, destination_port: destination_port, sailings: sailings)
+  end
+
+  let(:cheapest_sailing) { Sailing.new(origin_port: 'CNSHA', destination_port: "NLRTM", rate: "456.78", "rate_currency": "USD", usd: 1.1138) }
+  let(:sailings) do
+    [
+      cheapest_sailing,
+      Sailing.new(origin_port: 'CNSHA', destination_port: "NLRTM", rate: "456.78", "rate_currency": "EUR"),
+      Sailing.new(origin_port: 'CNSHA', destination_port: "NLRTM", rate: "97453", "rate_currency": "JPY", jpy: 149.93),
+      Sailing.new(origin_port: 'ESBCN', destination_port: "NLRTM", rate: "356.78", "rate_currency": "EUR")
+    ]
+  end
+
+  context 'origin_port and destination_port are valid' do
+    let(:origin_port) { 'CNSHA' }
+    let(:destination_port) { 'NLRTM' }
+
+    it 'returns the cheapest sailing' do
+      expect(subject.call.value!).to be(cheapest_sailing)
+    end
+  end
+
+  context 'origin_port or destination_port is invalid' do
+    let(:origin_port) { 'CNSHA' }
+    let(:destination_port) { 'QWERT' }
+    let(:error) { 'Invalid origin/destination port' }
+
+    it 'returns an error' do
+      expect(subject.call.failure).to eq(error)
+    end
+  end
+end


### PR DESCRIPTION
Acceptance criteria: Return the cheapest direct sailing between origin port & destination port in following format. For example using CNSHA as origin port & NLRTM as destination port input parameters

[
  {
    "origin_port": "CNSHA",
    "destination_port": "NLRTM",
    "departure_date": "2022-02-01",
    "arrival_date": "2022-03-01",
    "sailing_code": "ABCD",
    "rate": "589.30",
    "rate_currency": "USD"
  }
]